### PR TITLE
Updates to OS9 Network Runner

### DIFF
--- a/etc/ansible/roles/network-runner/providers/dellemc.os9.os9/conf_access_port.yaml
+++ b/etc/ansible/roles/network-runner/providers/dellemc.os9.os9/conf_access_port.yaml
@@ -1,9 +1,27 @@
 ---
+- name: "dellemc.os9: get running config for interface"
+  dellemc.os9.os9_command:
+    commands: "show running-config interface {{ port_name }}"
+  register: port_description_cmd
+  connection: network_cli
+
+- name: "dellemc.os9: get description from running config"
+  ansible.builtin.set_fact:
+    port_description: "{{ port_description_cmd.stdout[0] | regex_search('(?<=description ).+?(?=[\\n\\r])') }}"
+
 - name: "dellemc.os9: reset interface to default"
   dellemc.os9.os9_config:
     lines:
       - "default interface {{ port_name }}"
   connection: network_cli
+
+- name: "dellemc.os9: reassign description"
+  dellemc.os9.os9_config:
+    lines:
+      - "description {{ port_description }}"
+    parents: ["interface {{ port_name }}"]
+  connection: network_cli
+  when: port_description != ""
 
 - name: "dellemc.os9: enable switchport and jumbo frames"
   dellemc.os9.os9_config:

--- a/etc/ansible/roles/network-runner/providers/dellemc.os9.os9/conf_access_port.yaml
+++ b/etc/ansible/roles/network-runner/providers/dellemc.os9.os9/conf_access_port.yaml
@@ -14,6 +14,8 @@
     lines:
       - "default interface {{ port_name }}"
   connection: network_cli
+  retries: 5
+  delay: 2
 
 - name: "dellemc.os9: reassign description"
   dellemc.os9.os9_config:

--- a/etc/ansible/roles/network-runner/providers/dellemc.os9.os9/conf_access_port.yaml
+++ b/etc/ansible/roles/network-runner/providers/dellemc.os9.os9/conf_access_port.yaml
@@ -36,7 +36,7 @@
   dellemc.os9.os9_config:
     lines:
       - "interface {{ port_name }}"
-      - "spanning-tree rstp edge-port"
+      - "spanning-tree rstp edge-port bpduguard"
   connection: network_cli
   when: stp_edge
 

--- a/etc/ansible/roles/network-runner/providers/dellemc.os9.os9/conf_trunk_port.yaml
+++ b/etc/ansible/roles/network-runner/providers/dellemc.os9.os9/conf_trunk_port.yaml
@@ -1,9 +1,27 @@
 ---
+- name: "dellemc.os9: get running config for interface"
+  dellemc.os9.os9_command:
+    commands: "show running-config interface {{ port_name }}"
+  register: port_description_cmd
+  connection: network_cli
+
+- name: "dellemc.os9: get description from running config"
+  ansible.builtin.set_fact:
+    port_description: "{{ port_description_cmd.stdout[0] | regex_search('(?<=description ).+?(?=[\\n\\r])') }}"
+
 - name: "dellemc.os9: reset interface to default"
   dellemc.os9.os9_config:
     lines:
       - "default interface {{ port_name }}"
   connection: network_cli
+
+- name: "dellemc.os9: reassign description"
+  dellemc.os9.os9_config:
+    lines:
+      - "description {{ port_description }}"
+    parents: ["interface {{ port_name }}"]
+  connection: network_cli
+  when: port_description != ""
 
 - name: "dellemc.os9: enable switchport, hybrid portmode, and jumbo frames"
   dellemc.os9.os9_config:

--- a/etc/ansible/roles/network-runner/providers/dellemc.os9.os9/conf_trunk_port.yaml
+++ b/etc/ansible/roles/network-runner/providers/dellemc.os9.os9/conf_trunk_port.yaml
@@ -14,6 +14,8 @@
     lines:
       - "default interface {{ port_name }}"
   connection: network_cli
+  retries: 5
+  delay: 2
 
 - name: "dellemc.os9: reassign description"
   dellemc.os9.os9_config:

--- a/etc/ansible/roles/network-runner/providers/dellemc.os9.os9/conf_trunk_port.yaml
+++ b/etc/ansible/roles/network-runner/providers/dellemc.os9.os9/conf_trunk_port.yaml
@@ -37,7 +37,7 @@
   dellemc.os9.os9_config:
     lines:
       - "interface {{ port_name }}"
-      - "spanning-tree rstp edge-port"
+      - "spanning-tree rstp edge-port bpduguard"
   connection: network_cli
   when: stp_edge
 

--- a/etc/ansible/roles/network-runner/providers/dellemc.os9.os9/create_vlan.yaml
+++ b/etc/ansible/roles/network-runner/providers/dellemc.os9.os9/create_vlan.yaml
@@ -4,5 +4,4 @@
     lines:
       - "interface vlan {{ _vlan_id }}"
       - "name {{ _vlan_name }}"
-      - "no shutdown"
   connection: network_cli


### PR DESCRIPTION
3 Changes:

* If description exists on the port, it will be preserved after defaulting
* added BPDUguard to edgeports (kills the port if someone on the other end tries to join the spanning tree)
* Prevent ESI-created vlans from being in the `no shutdown` stage
* Adds bandaid fix for default command (retry until it succeeds for up to 5 times)