### PR TITLE
Added Logic to Manually Remove VLANs for OS9 Runner

### DIFF
--- a/etc/ansible/roles/network-runner/providers/dellemc.os9.os9/conf_access_port.yaml
+++ b/etc/ansible/roles/network-runner/providers/dellemc.os9.os9/conf_access_port.yaml
@@ -9,6 +9,55 @@
   ansible.builtin.set_fact:
     port_description: "{{ port_description_cmd.stdout[0] | regex_search('(?<=description ).+?(?=[\\n\\r])') }}"
 
+- name: "dellemc.os9: get existing vlans from running config"
+  dellemc.os9.os9_command:
+    commands: "show interfaces switchport {{ port_name }}"
+  register: port_vlans_cmd
+  connection: network_cli
+
+- name: "dellemc.os9: parse untagged vlan and tagged vlans from running config"
+  ansible.builtin.set_fact:
+    port_has_untagged: false
+    port_untagged: "{{ port_vlans_cmd.stdout[0] | regex_search('U\\s+(\\d+(?=[\\n\\r]|$))', '\\1') }}"
+    port_has_tagged: false
+    port_tagged: "{{ port_vlans_cmd.stdout[0] | regex_search('T\\s+([\\d,-]+(?=[\\n\\r]|$))', '\\1') }}"
+
+- name: "dellemc.os9: check if untagged vlan was found"
+  ansible.builtin.set_fact:
+    port_untagged_str: "{{ port_untagged[0] }}"
+    port_has_untagged: true
+  when: ( port_untagged is iterable ) and ( port_untagged is not string ) and ( port_untagged | length > 0 ) and ( port_untagged[0] != "1" )
+
+- name: "dellemc.os9: check if tagged vlans were found"
+  ansible.builtin.set_fact:
+    port_tagged_str: "{{ port_tagged[0] }}"
+    port_has_tagged: true
+    port_tagged_list: []
+  when: ( port_tagged is iterable ) and ( port_tagged is not string ) and ( port_tagged | length > 0 )
+
+- name: "dellemc.os9: parse ranges for tagged vlans"
+  ansible.builtin.set_fact:
+    port_tagged_list: "{{ port_tagged_list + (range(item.split('-')[0] | int, (item.split('-')[1] | int + 1)) | list if '-' in item else [item]) | map('string') }}"
+  loop: "{{ port_tagged_str.split(',') }}"
+  when: port_has_tagged
+
+- name: "dellemc.os9: Remove untagged vlan from port"
+  dellemc.os9.os9_config:
+    lines:
+      - "no untagged {{ port_name }}"
+    parents: ["interface Vlan {{ port_untagged_str }}"]
+  connection: network_cli
+  when: port_has_untagged
+
+- name: "dellemc.os9: Remove tagged vlans from port"
+  dellemc.os9.os9_config:
+    lines:
+      - "no tagged {{ port_name }}"
+    parents: ["interface Vlan {{ item }}"]
+  loop: "{{ port_tagged_list }}"
+  connection: network_cli
+  when: port_has_tagged
+
 - name: "dellemc.os9: reset interface to default"
   dellemc.os9.os9_config:
     lines:

--- a/etc/ansible/roles/network-runner/providers/dellemc.os9.os9/conf_access_port.yaml
+++ b/etc/ansible/roles/network-runner/providers/dellemc.os9.os9/conf_access_port.yaml
@@ -9,54 +9,13 @@
   ansible.builtin.set_fact:
     port_description: "{{ port_description_cmd.stdout[0] | regex_search('(?<=description ).+?(?=[\\n\\r])') }}"
 
-- name: "dellemc.os9: get existing vlans from running config"
-  dellemc.os9.os9_command:
-    commands: "show interfaces switchport {{ port_name }}"
-  register: port_vlans_cmd
-  connection: network_cli
-
-- name: "dellemc.os9: parse untagged vlan and tagged vlans from running config"
-  ansible.builtin.set_fact:
-    port_has_untagged: false
-    port_untagged: "{{ port_vlans_cmd.stdout[0] | regex_search('U\\s+(\\d+(?=[\\n\\r]|$))', '\\1') }}"
-    port_has_tagged: false
-    port_tagged: "{{ port_vlans_cmd.stdout[0] | regex_search('T\\s+([\\d,-]+(?=[\\n\\r]|$))', '\\1') }}"
-
-- name: "dellemc.os9: check if untagged vlan was found"
-  ansible.builtin.set_fact:
-    port_untagged_str: "{{ port_untagged[0] }}"
-    port_has_untagged: true
-  when: ( port_untagged is iterable ) and ( port_untagged is not string ) and ( port_untagged | length > 0 ) and ( port_untagged[0] != "1" )
-
-- name: "dellemc.os9: check if tagged vlans were found"
-  ansible.builtin.set_fact:
-    port_tagged_str: "{{ port_tagged[0] }}"
-    port_has_tagged: true
-    port_tagged_list: []
-  when: ( port_tagged is iterable ) and ( port_tagged is not string ) and ( port_tagged | length > 0 )
-
-- name: "dellemc.os9: parse ranges for tagged vlans"
-  ansible.builtin.set_fact:
-    port_tagged_list: "{{ port_tagged_list + (range(item.split('-')[0] | int, (item.split('-')[1] | int + 1)) | list if '-' in item else [item]) | map('string') }}"
-  loop: "{{ port_tagged_str.split(',') }}"
-  when: port_has_tagged
-
-- name: "dellemc.os9: Remove untagged vlan from port"
-  dellemc.os9.os9_config:
-    lines:
-      - "no untagged {{ port_name }}"
-    parents: ["interface Vlan {{ port_untagged_str }}"]
-  connection: network_cli
-  when: port_has_untagged
-
-- name: "dellemc.os9: Remove tagged vlans from port"
+- name: "dellemc.os9: Remove existing vlans from port"
   dellemc.os9.os9_config:
     lines:
       - "no tagged {{ port_name }}"
-    parents: ["interface Vlan {{ item }}"]
-  loop: "{{ port_tagged_list }}"
-  connection: network_cli
-  when: port_has_tagged
+      - "no untagged {{ port_name }}"
+    parents: ["interface range Vlan 2-4094"]
+  ignore_errors: true
 
 - name: "dellemc.os9: reset interface to default"
   dellemc.os9.os9_config:

--- a/etc/ansible/roles/network-runner/providers/dellemc.os9.os9/conf_access_port.yaml
+++ b/etc/ansible/roles/network-runner/providers/dellemc.os9.os9/conf_access_port.yaml
@@ -63,8 +63,6 @@
     lines:
       - "default interface {{ port_name }}"
   connection: network_cli
-  retries: 5
-  delay: 2
 
 - name: "dellemc.os9: reassign description"
   dellemc.os9.os9_config:

--- a/etc/ansible/roles/network-runner/providers/dellemc.os9.os9/conf_trunk_port.yaml
+++ b/etc/ansible/roles/network-runner/providers/dellemc.os9.os9/conf_trunk_port.yaml
@@ -9,6 +9,55 @@
   ansible.builtin.set_fact:
     port_description: "{{ port_description_cmd.stdout[0] | regex_search('(?<=description ).+?(?=[\\n\\r])') }}"
 
+- name: "dellemc.os9: get existing vlans from running config"
+  dellemc.os9.os9_command:
+    commands: "show interfaces switchport {{ port_name }}"
+  register: port_vlans_cmd
+  connection: network_cli
+
+- name: "dellemc.os9: parse untagged vlan and tagged vlans from running config"
+  ansible.builtin.set_fact:
+    port_has_untagged: false
+    port_untagged: "{{ port_vlans_cmd.stdout[0] | regex_search('U\\s+(\\d+(?=[\\n\\r]|$))', '\\1') }}"
+    port_has_tagged: false
+    port_tagged: "{{ port_vlans_cmd.stdout[0] | regex_search('T\\s+([\\d,-]+(?=[\\n\\r]|$))', '\\1') }}"
+
+- name: "dellemc.os9: check if untagged vlan was found"
+  ansible.builtin.set_fact:
+    port_untagged_str: "{{ port_untagged[0] }}"
+    port_has_untagged: true
+  when: ( port_untagged is iterable ) and ( port_untagged is not string ) and ( port_untagged | length > 0 ) and ( port_untagged[0] != "1" )
+
+- name: "dellemc.os9: check if tagged vlans were found"
+  ansible.builtin.set_fact:
+    port_tagged_str: "{{ port_tagged[0] }}"
+    port_has_tagged: true
+    port_tagged_list: []
+  when: ( port_tagged is iterable ) and ( port_tagged is not string ) and ( port_tagged | length > 0 )
+
+- name: "dellemc.os9: parse ranges for tagged vlans"
+  ansible.builtin.set_fact:
+    port_tagged_list: "{{ port_tagged_list + (range(item.split('-')[0] | int, (item.split('-')[1] | int + 1)) | list if '-' in item else [item]) | map('string') }}"
+  loop: "{{ port_tagged_str.split(',') }}"
+  when: port_has_tagged
+
+- name: "dellemc.os9: Remove untagged vlan from port"
+  dellemc.os9.os9_config:
+    lines:
+      - "no untagged {{ port_name }}"
+    parents: ["interface Vlan {{ port_untagged_str }}"]
+  connection: network_cli
+  when: port_has_untagged
+
+- name: "dellemc.os9: Remove tagged vlans from port"
+  dellemc.os9.os9_config:
+    lines:
+      - "no tagged {{ port_name }}"
+    parents: ["interface Vlan {{ item }}"]
+  loop: "{{ port_tagged_list }}"
+  connection: network_cli
+  when: port_has_tagged
+
 - name: "dellemc.os9: reset interface to default"
   dellemc.os9.os9_config:
     lines:

--- a/etc/ansible/roles/network-runner/providers/dellemc.os9.os9/conf_trunk_port.yaml
+++ b/etc/ansible/roles/network-runner/providers/dellemc.os9.os9/conf_trunk_port.yaml
@@ -9,54 +9,13 @@
   ansible.builtin.set_fact:
     port_description: "{{ port_description_cmd.stdout[0] | regex_search('(?<=description ).+?(?=[\\n\\r])') }}"
 
-- name: "dellemc.os9: get existing vlans from running config"
-  dellemc.os9.os9_command:
-    commands: "show interfaces switchport {{ port_name }}"
-  register: port_vlans_cmd
-  connection: network_cli
-
-- name: "dellemc.os9: parse untagged vlan and tagged vlans from running config"
-  ansible.builtin.set_fact:
-    port_has_untagged: false
-    port_untagged: "{{ port_vlans_cmd.stdout[0] | regex_search('U\\s+(\\d+(?=[\\n\\r]|$))', '\\1') }}"
-    port_has_tagged: false
-    port_tagged: "{{ port_vlans_cmd.stdout[0] | regex_search('T\\s+([\\d,-]+(?=[\\n\\r]|$))', '\\1') }}"
-
-- name: "dellemc.os9: check if untagged vlan was found"
-  ansible.builtin.set_fact:
-    port_untagged_str: "{{ port_untagged[0] }}"
-    port_has_untagged: true
-  when: ( port_untagged is iterable ) and ( port_untagged is not string ) and ( port_untagged | length > 0 ) and ( port_untagged[0] != "1" )
-
-- name: "dellemc.os9: check if tagged vlans were found"
-  ansible.builtin.set_fact:
-    port_tagged_str: "{{ port_tagged[0] }}"
-    port_has_tagged: true
-    port_tagged_list: []
-  when: ( port_tagged is iterable ) and ( port_tagged is not string ) and ( port_tagged | length > 0 )
-
-- name: "dellemc.os9: parse ranges for tagged vlans"
-  ansible.builtin.set_fact:
-    port_tagged_list: "{{ port_tagged_list + (range(item.split('-')[0] | int, (item.split('-')[1] | int + 1)) | list if '-' in item else [item]) | map('string') }}"
-  loop: "{{ port_tagged_str.split(',') }}"
-  when: port_has_tagged
-
-- name: "dellemc.os9: Remove untagged vlan from port"
-  dellemc.os9.os9_config:
-    lines:
-      - "no untagged {{ port_name }}"
-    parents: ["interface Vlan {{ port_untagged_str }}"]
-  connection: network_cli
-  when: port_has_untagged
-
-- name: "dellemc.os9: Remove tagged vlans from port"
+- name: "dellemc.os9: Remove existing vlans from port"
   dellemc.os9.os9_config:
     lines:
       - "no tagged {{ port_name }}"
-    parents: ["interface Vlan {{ item }}"]
-  loop: "{{ port_tagged_list }}"
-  connection: network_cli
-  when: port_has_tagged
+      - "no untagged {{ port_name }}"
+    parents: ["interface range Vlan 2-4094"]
+  ignore_errors: true
 
 - name: "dellemc.os9: reset interface to default"
   dellemc.os9.os9_config:

--- a/etc/ansible/roles/network-runner/providers/dellemc.os9.os9/conf_trunk_port.yaml
+++ b/etc/ansible/roles/network-runner/providers/dellemc.os9.os9/conf_trunk_port.yaml
@@ -63,8 +63,6 @@
     lines:
       - "default interface {{ port_name }}"
   connection: network_cli
-  retries: 5
-  delay: 2
 
 - name: "dellemc.os9: reassign description"
   dellemc.os9.os9_config:


### PR DESCRIPTION
This adds what we talked about @naved001 and @tzumainn. Tested on newest firmware OS9 switch for different port configs:
* One with VL623 and other tagged VLANs
* Just VL623
* No VLANs but still switchport
* No switchport

The steps are:
1. Run command on switch to get vlan info
2. Parse the actual strings we need from that output using regex
3. Check if we found untagged/tagged vlans and set variables accordingly
4. If tagged vlans are found, parse the range string into a list of strings (without ranges)
5. Remove untagged and tagged vlans from ports

@larsks I'm adding you as a reviewer on this as well. There are some relatively fancy data parsing going on here in ansible, I'd love to find out if there's a simpler way to do any of this.