### PR TITLE
feat: Added new NVUE driver

### DIFF
--- a/etc/ansible/roles/network-runner/providers/cumulus_nvue/add_trunk_vlan.yaml
+++ b/etc/ansible/roles/network-runner/providers/cumulus_nvue/add_trunk_vlan.yaml
@@ -1,0 +1,12 @@
+---
+- name: "nvue: Add a vlan to a trunk port"
+  nvidia.nvue.command:
+    commands:
+      - set interface {{ port_name }} bridge domain br_default vlan {{ _vlan_id }}
+  connection: ssh
+
+- name: "nvue: Apply and save config"
+  nvidia.nvue.command:
+    commands:
+      - config apply
+  connection: ssh

--- a/etc/ansible/roles/network-runner/providers/cumulus_nvue/conf_access_port.yaml
+++ b/etc/ansible/roles/network-runner/providers/cumulus_nvue/conf_access_port.yaml
@@ -1,0 +1,14 @@
+---
+- name: "nvue: Configure access port"
+  nvidia.nvue.command:
+    commands:
+      - set interface {{ port_name }} bridge domain br_default access {{ _vlan_id }}
+      - set interface {{ port_name }} bridge domain br_default stp admin-edge on
+      - set interface {{ port_name }} bridge domain br_default stp bpdu-guard on
+  connection: ssh
+
+- name: "nvue: Apply and save config"
+  nvidia.nvue.command:
+    commands:
+      - config apply
+  connection: ssh

--- a/etc/ansible/roles/network-runner/providers/cumulus_nvue/conf_trunk_port.yaml
+++ b/etc/ansible/roles/network-runner/providers/cumulus_nvue/conf_trunk_port.yaml
@@ -1,0 +1,14 @@
+---
+- name: "nvue: Configure trunk port"
+  nvidia.nvue.command:
+    commands:
+      - set interface {{ port_name }} bridge domain br_default vlan {{ _vlan_id }}
+      - set interface {{ port_name }} bridge domain br_default stp admin-edge on
+      - set interface {{ port_name }} bridge domain br_default stp bpdu-guard on
+  connection: ssh
+
+- name: "nvue: Apply and save config"
+  nvidia.nvue.command:
+    commands:
+      - config apply
+  connection: ssh

--- a/etc/ansible/roles/network-runner/providers/cumulus_nvue/create_vlan.yaml
+++ b/etc/ansible/roles/network-runner/providers/cumulus_nvue/create_vlan.yaml
@@ -1,0 +1,4 @@
+---
+- name: "nvue: Create vlan"
+  ansible.builtin.debug:
+    msg: "Creating VLAN skipped because it is intended to already exist on the switch"

--- a/etc/ansible/roles/network-runner/providers/cumulus_nvue/defaults.yaml
+++ b/etc/ansible/roles/network-runner/providers/cumulus_nvue/defaults.yaml
@@ -1,0 +1,3 @@
+---
+_vlan_id: "{{ vlan_id | default(1, True)}}"
+_vlan_name: '{{ vlan_name if vlan_name else "default" if vlan_id|string == "1" else "vlan"+vlan_id|string }}'

--- a/etc/ansible/roles/network-runner/providers/cumulus_nvue/delete_port.yaml
+++ b/etc/ansible/roles/network-runner/providers/cumulus_nvue/delete_port.yaml
@@ -1,0 +1,12 @@
+---
+- name: "nvue: Delete port"
+  nvidia.nvue.command:
+    commands:
+      - unset interface {{ port_name }} bridge
+  connection: ssh
+
+- name: "nvue: Apply and save config"
+  nvidia.nvue.command:
+    commands:
+      - config apply
+  connection: ssh

--- a/etc/ansible/roles/network-runner/providers/cumulus_nvue/delete_trunk_vlan.yaml
+++ b/etc/ansible/roles/network-runner/providers/cumulus_nvue/delete_trunk_vlan.yaml
@@ -1,0 +1,12 @@
+---
+- name: "nvue: Delete a vlan from a trunk port"
+  nvidia.nvue.command:
+    commands:
+      - unset interface {{ port_name }} bridge domain br_default vlan {{ _vlan_id }}
+  connection: ssh
+
+- name: "nvue: Apply and save config"
+  nvidia.nvue.command:
+    commands:
+      - config apply
+  connection: ssh

--- a/etc/ansible/roles/network-runner/providers/cumulus_nvue/delete_vlan.yaml
+++ b/etc/ansible/roles/network-runner/providers/cumulus_nvue/delete_vlan.yaml
@@ -1,0 +1,4 @@
+---
+- name: "nvue: Delete VLAN"
+  ansible.builtin.debug:
+    msg: "Delete VLAN skipped because it is intended to remain on the switch"

--- a/etc/ansible/roles/network-runner/providers/cumulus_nvue/get_port_conf.yaml
+++ b/etc/ansible/roles/network-runner/providers/cumulus_nvue/get_port_conf.yaml
@@ -1,0 +1,3 @@
+---
+- fail:
+    msg: Get Port Conf is not implimented for nvue

--- a/etc/ansible/roles/network-runner/providers/cumulus_nvue/list_vlans.yaml
+++ b/etc/ansible/roles/network-runner/providers/cumulus_nvue/list_vlans.yaml
@@ -1,0 +1,4 @@
+---
+- fail:
+    msg: List VLANs is not implimented for nvue
+


### PR DESCRIPTION
Adds NVUE support for network runner with ESI.

Notes:
* This driver uses `ssh` connection type instead of `network_cli`
  * Because of this, locally I had to install `sshpass` for ansible to be happy passing the password via the commandline. This might introduce complications with ESI, not sure.
* Cumulus/NVUE does have an API, but the ansible tasks for it are just not fleshed out enough. The documentation is wrong, particularly around deleting things. Looking at the code it's not even implemented and we need that for several items, so we have to go back to traditional SSH.
* This requires the `nvidia.nvue` collection
* These playbooks do not totally default an interface, only clear the bridge (which clears all vlans). Therefore, L1 parameters like MTU, state, etc. are set on the switch and ESI doesn't have to touch it at all.