### PR TITLE
cumulus_nvue: Manage link when configuring ports

### DIFF
--- a/etc/ansible/roles/network-runner/providers/cumulus_nvue/conf_access_port.yaml
+++ b/etc/ansible/roles/network-runner/providers/cumulus_nvue/conf_access_port.yaml
@@ -5,6 +5,7 @@
       - set interface {{ port_name }} bridge domain br_default access {{ _vlan_id }}
       - set interface {{ port_name }} bridge domain br_default stp admin-edge on
       - set interface {{ port_name }} bridge domain br_default stp bpdu-filter on
+      - set interface {{ port_name }} link state up
   connection: ssh
 
 - name: "nvue: Apply and save config"

--- a/etc/ansible/roles/network-runner/providers/cumulus_nvue/conf_trunk_port.yaml
+++ b/etc/ansible/roles/network-runner/providers/cumulus_nvue/conf_trunk_port.yaml
@@ -5,6 +5,7 @@
       - set interface {{ port_name }} bridge domain br_default untagged {{ _vlan_id}}
       - set interface {{ port_name }} bridge domain br_default stp admin-edge on
       - set interface {{ port_name }} bridge domain br_default stp bpdu-filter on
+      - set interface {{ port_name }} link state up
   connection: ssh
 
 - name: "nvue: Add trunk vlans"

--- a/etc/ansible/roles/network-runner/providers/cumulus_nvue/delete_port.yaml
+++ b/etc/ansible/roles/network-runner/providers/cumulus_nvue/delete_port.yaml
@@ -3,6 +3,7 @@
   nvidia.nvue.command:
     commands:
       - unset interface {{ port_name }} bridge
+      - set interface {{ port_name }} link state down
   connection: ssh
 
 - name: "nvue: Apply and save config"


### PR DESCRIPTION
Ensure that we bring the link state down when deleting a port (and bring it
back up when configuring a port). These link state changes provide
notifications to connected systems that they should attempt to immediately
re-acquire a DHCP lease. This allows systems to respond quickly when we
move them between networks.

Closes: cci-moc/ops-issues#1530
